### PR TITLE
Copy KLV Database

### DIFF
--- a/MiDemux/CMakeLists.txt
+++ b/MiDemux/CMakeLists.txt
@@ -31,6 +31,8 @@ find_package(Microsoft.GSL CONFIG REQUIRED)
 set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost REQUIRED COMPONENTS property_tree)
 
+file(COPY ${klvp_DIR}/../../../share/klv.s3db DESTINATION ${CMAKE_BINARY_DIR})
+
 add_library(MiDemux STATIC)
 
 target_sources(MiDemux 

--- a/MiDemux/src/KlvDecodeVisitor.cpp
+++ b/MiDemux/src/KlvDecodeVisitor.cpp
@@ -1,4 +1,4 @@
-#include "KLVDecodeVisitor.h"
+#include "KlvDecodeVisitor.h"
 
 #include <klvp/decode.h>
 #include <iostream>


### PR DESCRIPTION
During configuring the build environment, copy the KLV database (klv.s3db) in the build directory.
Fix compiler error on Linux