### PR TITLE
Send Text Representation over UDP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,28 +13,44 @@ include(GNUInstallDirs)
 add_subdirectory (MiDemux)
 
 set(Boost_USE_STATIC_LIBS ON)
-find_package(Boost REQUIRED COMPONENTS algorithm json program_options)
+find_package(Boost REQUIRED COMPONENTS algorithm json program_options url)
 
 add_executable(KlvDecoder)
 
 target_sources(KlvDecoder
   PRIVATE
     src/main.cpp
-	src/CmdLineParser.cpp
-	src/CmdLineParser.h
+    src/CmdLineParser.cpp
+    src/CmdLineParser.h
+    src/UdpSender.cpp
+    src/UdpSender.h
 )
 
 target_include_directories(KlvDecoder
   PRIVATE
     ${Boost_INCLUDE_DIRS})
 
+if (WIN32)
 target_link_libraries(KlvDecoder 
   PRIVATE
     MiDemux
     Boost::algorithm
     Boost::json
     Boost::program_options
+    Boost::url
+    wsock32
+    ws2_32
 )
+else()
+target_link_libraries(KlvDecoder 
+  PRIVATE
+    MiDemux
+    Boost::algorithm
+    Boost::json
+    Boost::program_options
+    Boost::url
+)
+endif()
 
 install(TARGETS KlvDecoder)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,12 +61,7 @@ add_test(NAME OutputJson
   COMMAND KlvDecoder ${PROJECT_SOURCE_DIR}/sample/foreman_cif_klv.ts
 )
 set_tests_properties(OutputJson
-  PROPERTIES PASS_REGULAR_EXPRESSION "{
-    \"metadata_set\": {
-        \"UNIX_Time_Stamp\": {
-            \"key\": \"2\",
-            \"value\": \"Friday, 16-Jun-17 14:26:20.616000 UTC\"
-        },"
+  PROPERTIES PASS_REGULAR_EXPRESSION "{\"metadata_set\":{\"UNIX_Time_Stamp\":{\"key\":\"2\",\"value\":\"Friday, 16-Jun-17 14:26:20.616000 UTC\"},"
 )
 
 add_test(NAME OutputXml
@@ -87,4 +82,8 @@ set_tests_properties(OutputInfo
         key 2
         value \"Friday, 16-Jun-17 14:26:20.616000 UTC\"
     }"
+)
+
+add_test(NAME StreamOutput
+  COMMAND KlvDecoder ${PROJECT_SOURCE_DIR}/sample/foreman_cif_klv.ts --outputUrl=udp://239.3.1.11:50000?ttl=16
 )

--- a/MiDemux/src/KlvDecodeVisitor.cpp
+++ b/MiDemux/src/KlvDecodeVisitor.cpp
@@ -91,7 +91,7 @@ namespace
         obj["length"] = klv.length();
         obj["value"] = val.str();*/
 
-        obj.put("key", klv.key());
+        obj.put<int>("key", klv.key());
         obj.put("value", val.str());
 
         pt::ptree::value_type vt(space2underscore(lds.name), obj);
@@ -115,8 +115,8 @@ namespace
         obj["key"] = klv.key();
         obj["length"] = klv.length();
         obj["value"] = val;*/
-        obj.put("key", klv.key());
-        obj.put("value", val);
+        obj.put<int>("key", klv.key());
+        obj.put<float>("value", val);
         pt::ptree::value_type vt(space2underscore(lds.name), obj);
 
         return vt;
@@ -135,8 +135,8 @@ namespace
         obj["key"] = klv.key();
         obj["length"] = klv.length();
         obj["value"] = val;*/
-        obj.put("key", klv.key());
-        obj.put("value", val);
+        obj.put<int>("key", klv.key());
+        obj.put<int>("value", val);
         pt::ptree::value_type vt(space2underscore(lds.name), obj);
 
         return vt;
@@ -156,7 +156,7 @@ namespace
         obj["key"] = klv.key();
         obj["length"] = klv.length();
         obj["value"] = "To Be Implemented";*/
-        obj.put("key", klv.key());
+        obj.put<int>("key", klv.key());
         obj.put("value", "To be Implemented");
         pt::ptree::value_type vt(space2underscore(lds.name), obj);
 
@@ -196,7 +196,7 @@ namespace
         obj["key"] = klv.key();
         obj["length"] = klv.length();
         obj["value"] = timebuf;*/
-        obj.put("key", klv.key());
+        obj.put<int>("key", klv.key());
         obj.put("value", std::string(timebuf));
 
         pt::ptree::value_type vt(space2underscore(lds.name), obj);
@@ -257,7 +257,7 @@ void KLVDecodeVisitor::Visit(lcss::KLVUnknown& klv)
     obj["length"] = klv.length();
     obj["value"] = strval.str();*/
 
-    obj.put("key", klv.key());
+    obj.put<int>("key", klv.key());
     obj.put("value", strval.str());
     pt::ptree::value_type vt("UNKNOWN", obj);
 
@@ -286,7 +286,7 @@ void KLVDecodeVisitor::Visit(lcss::KLVParseError& klv)
     obj["what"] = klv.what_;
     obj["value"] = strval.str();*/
 
-    obj.put("key", klv.key());
+    obj.put<int>("key", klv.key());
     obj.put("value", strval.str());
     pt::ptree::value_type vt("PARSE ERROR", obj);
 
@@ -312,7 +312,7 @@ void KLVDecodeVisitor::Visit(lcss::KLVChecksum& klv)
     obj["key"] = klv.key();
     obj["length"] = klv.length();
     obj["value"] = crc;*/
-    obj.put("key", klv.key());
+    obj.put<int>("key", klv.key());
     obj.put("value", std::string(crc));
     pt::ptree::value_type vt(space2underscore(lds.name), obj);
 
@@ -597,7 +597,7 @@ void KLVDecodeVisitor::Visit(lcss::KLVGenericFlagData01& klv)
     obj["key"] = klv.key();
     obj["length"] = klv.length();
     obj["value"] = *klv.value();*/
-    obj.put("key", klv.key());
+    obj.put<int>("key", klv.key());
     obj.put("value", *klv.value());
     pt::ptree::value_type vt("Generic_Flag_Data_01", obj);
     _klvSet.push_back(vt);
@@ -913,7 +913,7 @@ void KLVDecodeVisitor::Visit(lcss::KLVMIISCoreIdentifier& klv)
     obj["key"] = klv.key();
     obj["length"] = klv.length();
     obj["value"] = uuid;*/
-    obj.put("key", klv.key());
+    obj.put<int>("key", klv.key());
     obj.put("value", std::string(uuid));
     pt::ptree::value_type vt(space2underscore(lds.name), obj);
 

--- a/README.md
+++ b/README.md
@@ -65,18 +65,32 @@ The `-C` option specifies the build configuration to test, either `Debug` or `Re
 KlvDecoder v1.0.0
 Copyright (c) 2025 ThetaStream Consulting, jimcavoy@thetastream.com
 Allowed options.:
-  -? [ --help ]         Produce help message.
-  --source arg          Source Motion Imagery stream or file. (default: - )
-  -r [ --reads ] arg    Number of KLV reads. Zero means continuous reads.
-                        (default: 0
-  -f [ --freqs ] arg    Frequency (Hz) to output the text representation.
-                        (default: 1)
-  -F [ --format ] arg   Output text format [info|json|xml]. (default: json).
+  -? [ --help ]          Produce help message.
+  --source arg           Source Motion Imagery stream or file. (default: - )
+  -r [ --reads ] arg     Number of KLV reads. Zero means continuous reads.
+                         (default: 0
+  -f [ --freqs ] arg     Frequency (Hz) to output the text representation.
+                         (default: 1)
+  -F [ --format ] arg    Output text format [info|json|xml]. (default: json).
+  -o [ --outputUrl ] arg Stream the text representation over UDP. If the option
+                         is missing, output to console. (default: - )
+```
+The `--outputUrl` option has an optional query component with the following attribute-value pairs:
+
+- __ttl__. The time-to-live parameter.
+- __localaddr__. Transmit on a network adapter with an assigned IP address.
+
+For example, you want to stream using UDP on a multicast address of 239.3.1.11 with a time-to-live of 16 and transmit
+onto a network adapter with an assigned IP address of 192.168.0.24:
+
+```
+--outputUrl=udp://239.3.1.11:50000?ttl=16&localaddr=192.168.0.24
 ```
 
+__Note__: Presently, __KlvDecoder__ only supports UDP protocol.
 ## Examples
 
-### Read a File
+### 1. Read a File
 In this example, output a JSON representation of the KLV encoded metadata from a
 STANAG 4609 Motion Imagery file.
 
@@ -84,10 +98,17 @@ STANAG 4609 Motion Imagery file.
 KlvDeoder C:\somefolder\sample_file.ts -F json
 ```
 
-### Read a Stream
-In this example, output an XML representation of the KLV encoded metadata from a 
+### 2. Read a Stream
+In this example, output to console an XML representation of the KLV encoded metadata from a 
 STANAG 4609 stream being piped in from __IReflxApp__ application.
 
 ```
 IReflxApp.exe -s 239.255.0.1:1841 | KlvDecoder.exe -F xml
+```
+
+### 3. Read a Stream and Stream the Result
+In this example, stream the XML representation over UDP from a STANAG 4609 stream being
+piped in from __IReflxApp__ application.
+```
+IReflxApp.exe -s 239.255.0.1:1841 | KlvDecoder.exe -F xml --outputUrl=udp://239.3.1.11:50000
 ```

--- a/src/CmdLineParser.cpp
+++ b/src/CmdLineParser.cpp
@@ -44,7 +44,7 @@ int CmdLineParser::parse(int argc, char** argv)
             ("reads,r", po::value<int>(&_pimpl->_reads), "Number of KLV reads. Zero means continuous reads. (default: 0")
             ("freqs,f", po::value<float>(&_pimpl->_frequency), "Frequency (Hz) to output the text representation. (default: 1)")
             ("format,F", po::value<std::string>(&_pimpl->_format), "Output text format [info|json|xml]. (default: json).")
-            ("outputUrl,o", po::value<std::string>(&_pimpl->_outputUrl), "Output URL. (default: stdout).")
+            ("outputUrl,o", po::value<std::string>(&_pimpl->_outputUrl), "Stream the text representation over UDP. If the option is missing, output to console. (default: - )")
             ;
 
         po::command_line_parser parser{ argc, argv };

--- a/src/CmdLineParser.cpp
+++ b/src/CmdLineParser.cpp
@@ -15,6 +15,7 @@ public:
     float _frequency{ 1 };
     std::string _format{ "json" };
     std::string _source{ "-" };
+    std::string _outputUrl{ "-" };
 };
 
 CmdLineParser::CmdLineParser()
@@ -43,6 +44,7 @@ int CmdLineParser::parse(int argc, char** argv)
             ("reads,r", po::value<int>(&_pimpl->_reads), "Number of KLV reads. Zero means continuous reads. (default: 0")
             ("freqs,f", po::value<float>(&_pimpl->_frequency), "Frequency (Hz) to output the text representation. (default: 1)")
             ("format,F", po::value<std::string>(&_pimpl->_format), "Output text format [info|json|xml]. (default: json).")
+            ("outputUrl,o", po::value<std::string>(&_pimpl->_outputUrl), "Output URL. (default: stdout).")
             ;
 
         po::command_line_parser parser{ argc, argv };
@@ -103,4 +105,9 @@ CmdLineParser::FORMAT CmdLineParser::format() const
 std::string CmdLineParser::source() const
 {
     return _pimpl->_source;
+}
+
+std::string CmdLineParser::outputUrl() const
+{
+    return _pimpl->_outputUrl;
 }

--- a/src/CmdLineParser.h
+++ b/src/CmdLineParser.h
@@ -23,6 +23,7 @@ public:
     float frequency() const;
     FORMAT format() const;
     std::string source() const;
+    std::string outputUrl() const;
 
 private:
     class Impl;

--- a/src/UdpSender.cpp
+++ b/src/UdpSender.cpp
@@ -190,20 +190,33 @@ void UdpSender::send(const char* data, size_t length)
     }
     else // Send the data onto a socket
     {
-        const int status = sendto(_pimpl->_socket,
-            data,
-            (int)length,
-            0,
-            (SOCKADDR*)&_pimpl->_recvAddr,
-            sizeof(_pimpl->_recvAddr));
-
-        if (status == SOCKET_ERROR)
+        int bufsiz = 1000;
+        int nLeft = length;
+        size_t i = 0;
+        while (i < length)
         {
+            if (nLeft < bufsiz)
+            {
+                bufsiz = nLeft;
+            }
+
+            const int status = sendto(_pimpl->_socket,
+                data+i,
+                bufsiz,
+                0,
+                (SOCKADDR*)&_pimpl->_recvAddr,
+                sizeof(_pimpl->_recvAddr));
+
+            if (status == SOCKET_ERROR)
+            {
 #ifdef _WIN32
-            const UINT32 errCode = WSAGetLastError();
+                const UINT32 errCode = WSAGetLastError();
 #else
-            const int errCode = errno;
+                const int errCode = errno;
 #endif
+            }
+            i += 1000;
+            nLeft -= 1000;
         }
     }
 }

--- a/src/UdpSender.cpp
+++ b/src/UdpSender.cpp
@@ -1,0 +1,209 @@
+#include "UdpSender.h"
+
+#include <iostream>
+#include <fcntl.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <io.h>
+#include <WinSock2.h>
+#include <WS2tcpip.h>
+#else
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <errno.h>
+#endif
+
+#ifdef _WIN32
+#define sprintf sprintf_s
+#else
+#define sprintf sprintf
+#define SOCKET int
+#define INVALID_SOCKET -1
+#define SOCKET_ERROR -1
+#define PVOID void*
+#define SD_SEND SHUT_WR
+#define SOCKADDR sockaddr
+#define IN_ADDR in_addr
+#endif
+
+
+using namespace std;
+const int BUFLEN = 1500;
+
+class UdpSender::Impl
+{
+public:
+    Impl(uint32_t port)
+        : _port(port)
+    {
+    }
+
+    ~Impl()
+    {
+        if (_socket != INVALID_SOCKET)
+        {
+            shutdown(_socket, SD_SEND);
+#ifdef _WIN32
+            closesocket(_socket);
+#else
+            close(_pimpl->_socket);
+#endif
+        }
+    }
+
+public:
+    void initSocket(const char* ipaddr, uint16_t port, unsigned char ttl, const char* iface_addr);
+
+public:
+    SOCKET _socket{ INVALID_SOCKET };
+    bool _run{ true };
+    sockaddr_in _recvAddr{};
+    uint32_t _address{};
+    uint16_t _port{};
+};
+
+UdpSender::UdpSender(const char* ipaddr, uint16_t port, unsigned char ttl, const char* iface_addr)
+    : _pimpl(std::make_unique<UdpSender::Impl>(port))
+{
+    if (strcmp(ipaddr, "-") == 0) // send the data onto a socket
+    {
+#ifdef _WIN32
+        _setmode(_fileno(stdout), _O_BINARY);
+#endif
+    }
+    else // write the data to stdout
+    {
+        _pimpl->initSocket(ipaddr, port, ttl, iface_addr);
+    }
+}
+
+UdpSender::~UdpSender(void)
+{
+
+}
+
+void UdpSender::Impl::initSocket(const char* ipaddr, uint16_t port, unsigned char ttl, const char* iface_addr)
+{
+    char szErr[BUFSIZ]{};
+    IN_ADDR inaddr;
+#ifdef _WIN32
+    WORD winsock_version, err;
+    WSADATA winsock_data;
+    winsock_version = MAKEWORD(2, 2);
+
+    err = WSAStartup(winsock_version, &winsock_data);
+    if (err != 0)
+    {
+        std::exception exp("Failed to initialize WinSock");
+        throw exp;
+    }
+#endif
+
+    //----------------------
+    // Create a SOCKET for connecting to server
+    _socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (_socket == INVALID_SOCKET) {
+#ifdef _WIN32
+        WSACleanup();
+        sprintf(szErr, "Error at socket(): %d", WSAGetLastError());
+#else
+        sprintf(szErr, "Error at socket(): %d", errno);
+#endif
+        std::runtime_error exp(szErr);
+        throw exp;
+    }
+
+    // Set time to live
+    unsigned char optVal = ttl;
+    int optLen = sizeof(optVal);
+
+    if (setsockopt(_socket, IPPROTO_IP, IP_MULTICAST_TTL, (char*)&optVal, optLen) == SOCKET_ERROR)
+    {
+#ifdef _WIN32
+        WSACleanup();
+        sprintf(szErr, "Error setting socket option IP_MULTICAST_TTL: %d", WSAGetLastError());
+#else
+        sprintf(szErr, "Error setting socket option IP_MULICAST_TTL: %d", errno);
+#endif
+        std::runtime_error exp(szErr);
+        throw exp;
+    }
+
+    if (strlen(iface_addr) > 0)
+    {
+        inet_pton(AF_INET, iface_addr, (PVOID)&inaddr);
+        if (setsockopt(_socket, IPPROTO_IP, IP_MULTICAST_IF, (char*)&inaddr.s_addr, sizeof(inaddr.s_addr)) == SOCKET_ERROR)
+        {
+#ifdef _WIN32
+            WSACleanup();
+            sprintf(szErr, "UdpSender Error setting socket option IP_MULTICAST_IF: %d", WSAGetLastError());
+#else
+            sprintf(szErr, "UdpSender Error setting socket option IP_MULTICAST_IF: %d", errno);
+#endif
+            std::runtime_error exp(szErr);
+            throw exp;
+        }
+    }
+
+    if (inet_pton(AF_INET, ipaddr, (PVOID)&inaddr) != 1)
+    {
+#ifdef _WIN32
+        WSACleanup();
+        sprintf_s(szErr, "Error when calling inet_pton: %d", WSAGetLastError());
+#else
+        sprintf(szErr, "Error when calling inet_pton: %d", errno);
+#endif
+        std::runtime_error exp(szErr);
+        throw exp;
+    }
+    //----------------------
+    // The sockaddr_in structure specifies the address family,
+    // IP address, and port for the socket that is being send to
+    _recvAddr.sin_family = AF_INET;
+    _recvAddr.sin_addr.s_addr = inaddr.s_addr;
+    _recvAddr.sin_port = htons(port);
+
+    _address = _recvAddr.sin_addr.s_addr;
+}
+
+void UdpSender::send(const char* data, size_t length)
+{
+    // Write the data to the standard console out
+    if (_pimpl->_socket == INVALID_SOCKET)
+    {
+        size_t w = 0;
+        for (size_t nleft = length; nleft > 0;)
+        {
+            w = fwrite(data, 1, nleft, stdout);
+            if (w == 0)
+            {
+                std::cerr << "error: unable to write " << nleft << " bytes to stdout" << std::endl;
+            }
+            nleft -= w;
+            fflush(stdout);
+        }
+    }
+    else // Send the data onto a socket
+    {
+        const int status = sendto(_pimpl->_socket,
+            data,
+            (int)length,
+            0,
+            (SOCKADDR*)&_pimpl->_recvAddr,
+            sizeof(_pimpl->_recvAddr));
+
+        if (status == SOCKET_ERROR)
+        {
+#ifdef _WIN32
+            const UINT32 errCode = WSAGetLastError();
+#else
+            const int errCode = errno;
+#endif
+        }
+    }
+}

--- a/src/UdpSender.h
+++ b/src/UdpSender.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <memory>
+
+class UdpSender
+{
+public:
+    UdpSender(const char* ipaddr, unsigned short port, unsigned char ttl, const char* iface_addr);
+    ~UdpSender();
+
+    void send(const char* buffer, size_t len);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> _pimpl;
+};
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,71 +103,84 @@ int main(int argc, char* argv[])
         return retCode;
     }
 
-    MiDemux demux(args.frequency());
-    UrlParser urlp;
-    urlp.parse(args.outputUrl());
-    UdpSender writer(urlp.ipaddress.c_str(), urlp.port, urlp.ttl, urlp.ifaceaddress.c_str());
-
-    if (args.source() == "-")
+    try
     {
+        MiDemux demux(args.frequency());
+        UrlParser urlp;
+        urlp.parse(args.outputUrl());
+        UdpSender writer(urlp.ipaddress.c_str(), urlp.port, urlp.ttl, urlp.ifaceaddress.c_str());
+
+        if (args.source() == "-")
+        {
 #ifdef _WIN32
-        _setmode(_fileno(stdin), _O_BINARY);
+            _setmode(_fileno(stdin), _O_BINARY);
 #endif
-        ifile.reset(&std::cin, [](...) {});
-    }
-    else
-    {
-        std::ifstream* tsfile = new std::ifstream(args.source(), std::ios::binary);
-        if (!tsfile->is_open())
-        {
-            std::cerr << "ERROR: Failed to open file, " << args.source() << std::endl;
-            return -1;
-        }
-        ifile.reset(tsfile);
-    }
-
-    while (gRun)
-    {
-        if (ifile->good())
-        {
-            ifile->read((char*)buffer.data(), buffer.size());
-            const std::streamsize len = ifile->gcount();
-
-            demux.read(buffer.data(), len);
-
-            demux.setKlvSetCallback([&](const pt::ptree& klvset)
-                {
-                    std::stringstream output;
-                    switch (args.format())
-                    {
-                    case CmdLineParser::FORMAT::JSON:
-                        pt::write_json(output, klvset);
-                        break;
-                    case CmdLineParser::FORMAT::XML:
-                        pt::write_xml(output, klvset, pt::xml_parser::trim_whitespace);
-                        break;
-                    case CmdLineParser::FORMAT::INFO:
-                        pt::write_info(output, klvset);
-                        break;
-                    default:
-                        std::cerr << "Unknown Format" << std::endl;
-                    }
-
-                    if (!output.str().empty())
-                    {
-                        writer.send(output.str().c_str(), output.str().length());
-                    }
-                });
+            ifile.reset(&std::cin, [](...) {});
         }
         else
         {
-            gRun = false;
+            std::ifstream* tsfile = new std::ifstream(args.source(), std::ios::binary);
+            if (!tsfile->is_open())
+            {
+                std::cerr << "ERROR: Failed to open file, " << args.source() << std::endl;
+                return -1;
+            }
+            ifile.reset(tsfile);
         }
 
-        if (demux.reads() >= args.reads() && args.reads() > 0)
+        while (gRun)
         {
-            gRun = false;
+            if (ifile->good())
+            {
+                ifile->read((char*)buffer.data(), buffer.size());
+                const std::streamsize len = ifile->gcount();
+
+                demux.read(buffer.data(), len);
+
+                demux.setKlvSetCallback([&](const pt::ptree& klvset)
+                    {
+                        std::stringstream output;
+                        switch (args.format())
+                        {
+                        case CmdLineParser::FORMAT::JSON:
+                            pt::write_json(output, klvset, false);
+                            break;
+                        case CmdLineParser::FORMAT::XML:
+                            pt::write_xml(output, klvset, pt::xml_parser::trim_whitespace);
+                            break;
+                        case CmdLineParser::FORMAT::INFO:
+                            pt::write_info(output, klvset);
+                            break;
+                        default:
+                            std::cerr << "Unknown Format" << std::endl;
+                        }
+
+                        if (!output.str().empty())
+                        {
+                            writer.send(output.str().c_str(), output.str().length());
+                        }
+                    });
+            }
+            else
+            {
+                gRun = false;
+            }
+
+            if (demux.reads() >= args.reads() && args.reads() > 0)
+            {
+                gRun = false;
+            }
         }
+    }
+    catch (const std::exception& ex)
+    {
+        std::cerr << "ERROR: " << ex.what() << std::endl;
+        return -1;
+    }
+    catch (...)
+    {
+        std::cerr << "ERROR: Unknown exception caught." << std::endl;
+        return -1;
     }
 
     return retCode;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,8 +3,9 @@
     "boost-algorithm",
     "boost-json",
     "boost-program-options",
-    "ms-gsl",
     "boost-property-tree",
+    "boost-url",
+    "ms-gsl",
     "sqlite3"
   ]
 }


### PR DESCRIPTION
Added a new option `--outputUrl|-o` to allow users to send the KLV text representation over UDP.