### PR TITLE
Improve json output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ add_test(NAME OutputJson
   COMMAND KlvDecoder ${PROJECT_SOURCE_DIR}/sample/foreman_cif_klv.ts
 )
 set_tests_properties(OutputJson
-  PROPERTIES PASS_REGULAR_EXPRESSION "{\"metadata_set\":{\"UNIX_Time_Stamp\":{\"key\":\"2\",\"value\":\"Friday, 16-Jun-17 14:26:20.616000 UTC\"},"
+  PROPERTIES PASS_REGULAR_EXPRESSION "{\"metadata_set\":{\"UNIX_Time_Stamp\":{\"key\":2,\"value\":\"Friday, 16-Jun-17 14:26:20.616000 UTC\"},"
 )
 
 add_test(NAME OutputXml


### PR DESCRIPTION
Use template specialization to override the boost write_json_helper function so value is a number print it out as number and not a quoted string.