### PR TITLE
10 klvdecoder fails to read stream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 cmake_minimum_required (VERSION 3.21)
 project (KlvDecoder
-	VERSION 1.0.0
+	VERSION 1.0.1
 	DESCRIPTION "Converts KLV binary encoded metadata in a STANAG 4609 Motion Imagery stream to a human readable text format."
 	LANGUAGES CXX)
 

--- a/MiDemux/CMakeLists.txt
+++ b/MiDemux/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.21)
 
 project(MiDemux
-  VERSION 1.0.0
+  VERSION 1.0.1
   DESCRIPTION "STANAG 4609 Motion Imagery De-multiplexer"
   LANGUAGES CXX
 )

--- a/MiDemux/src/Mpeg2TsDecoder.cpp
+++ b/MiDemux/src/Mpeg2TsDecoder.cpp
@@ -121,12 +121,12 @@ void Mpeg2TsDecoder::processKlv(const lcss::PESPacket& pes)
             {
                 stream_id = 0xBD;
             }
+        }
 
-            if (stream_id == 0xBD)
-            {
-                _klvParser.parse({ (BYTE*)_klvSample.data(), (UINT32)_klvSample.length() });
-                outputSet();
-            }
+        if (stream_id == 0xBD)
+        {
+            _klvParser.parse({ (BYTE*)_klvSample.data(), (UINT32)_klvSample.length() });
+            outputSet();
         }
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -271,7 +271,7 @@ int main(int argc, char* argv[])
 
 void Banner()
 {
-    std::cerr << "KlvDecoder v1.0.0" << std::endl;
+    std::cerr << "KlvDecoder v1.0.1" << std::endl;
     std::cerr << "Copyright (c) 2025 ThetaStream Consulting, jimcavoy@thetastream.com" << std::endl;
 }
 


### PR DESCRIPTION
If the carriage for KLV is async, the KlvDecoder failed to process the KLV set.  This commit fixes this issue.