### PR TITLE
14 specify the file location of the lds database

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 cmake_minimum_required (VERSION 3.21)
 project (KlvDecoder
-	VERSION 1.0.1
+	VERSION 1.2.0
 	DESCRIPTION "Converts KLV binary encoded metadata in a STANAG 4609 Motion Imagery stream to a human readable text format."
 	LANGUAGES CXX)
 

--- a/MiDemux/CMakeLists.txt
+++ b/MiDemux/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.21)
 
 project(MiDemux
-  VERSION 1.0.1
+  VERSION 1.2.0
   DESCRIPTION "STANAG 4609 Motion Imagery De-multiplexer"
   LANGUAGES CXX
 )

--- a/MiDemux/include/MiDemux/MiDemux.h
+++ b/MiDemux/include/MiDemux/MiDemux.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include <boost/property_tree/ptree.hpp>
 
@@ -12,7 +13,7 @@ public:
     typedef std::function<void(const pt::ptree& klvset)> OnKlvSet;
 
 public:
-    MiDemux(float frequency);
+    MiDemux(float frequency, const std::string& klvdbFilepath);
     ~MiDemux();
 
     void read(const uint8_t* stream, size_t len);

--- a/MiDemux/src/KlvParserImpl.cpp
+++ b/MiDemux/src/KlvParserImpl.cpp
@@ -9,6 +9,12 @@ const char* dbUrl = "file:///usr/local/share/klv.s3db";
 #endif
 
 KlvParserImpl::KlvParserImpl()
+    :_klvdbFilepath(dbUrl)
+{
+}
+
+KlvParserImpl::KlvParserImpl(std::string path)
+    :_klvdbFilepath(path)
 {
     validateChecksum(true);
 }
@@ -27,7 +33,7 @@ void KlvParserImpl::onElement(lcss::KLVElement& klv)
 {
     lcss::KLVParser::onElement(klv);
     _count++;
-    KlvDecodeVisitor vis(_elements, dbUrl);
+    KlvDecodeVisitor vis(_elements, _klvdbFilepath.c_str());
     klv.Accept(vis);
 }
 
@@ -65,4 +71,9 @@ void KlvParserImpl::clear()
 {
     _klvSet.clear();
     _elements.clear();
+}
+
+void KlvParserImpl::setKlvdbFilepath(const std::string& filepath)
+{
+    _klvdbFilepath = filepath;
 }

--- a/MiDemux/src/KlvParserImpl.h
+++ b/MiDemux/src/KlvParserImpl.h
@@ -2,6 +2,7 @@
 
 #include <klvp/klvprsr.h>
 #include <boost/property_tree/ptree.hpp>
+#include <string>
 
 namespace pt = boost::property_tree;
 
@@ -10,6 +11,7 @@ class KlvParserImpl :
 {
 public:
     KlvParserImpl();
+    KlvParserImpl(std::string klvdbFilepath);
     virtual ~KlvParserImpl();
 
     void onBeginSet(int len, lcss::TYPE type) override;
@@ -22,9 +24,12 @@ public:
     const pt::ptree& klvSet() const;
     void clear();
 
+    void setKlvdbFilepath(const std::string& filepath);
+
 private:
     int                 _count{ 0 };
     lcss::TYPE          _type{ lcss::TYPE::LOCAL_SET };
     pt::ptree           _klvSet;
     pt::ptree           _elements;
+    std::string         _klvdbFilepath;
 };

--- a/MiDemux/src/MiDemux.cpp
+++ b/MiDemux/src/MiDemux.cpp
@@ -6,8 +6,8 @@
 class MiDemux::Impl
 {
 public:
-    Impl(float frequency)
-        :_decoder(std::make_unique<Mpeg2TsDecoder>(frequency))
+    Impl(float frequency, const std::string& klvdbFilepath)
+        :_decoder(std::make_unique<Mpeg2TsDecoder>(frequency, klvdbFilepath))
     {
 
     }
@@ -16,8 +16,8 @@ public:
 };
 
 
-MiDemux::MiDemux(float frequency)
-    :_pimpl(std::make_unique<MiDemux::Impl>(frequency))
+MiDemux::MiDemux(float frequency, const std::string& klvdbFilepath)
+    :_pimpl(std::make_unique<MiDemux::Impl>(frequency, klvdbFilepath))
 {
 }
 

--- a/MiDemux/src/Mpeg2TsDecoder.cpp
+++ b/MiDemux/src/Mpeg2TsDecoder.cpp
@@ -3,10 +3,10 @@
 #include <iterator>
 
 
-Mpeg2TsDecoder::Mpeg2TsDecoder(float frequency)
+Mpeg2TsDecoder::Mpeg2TsDecoder(float frequency, const std::string& klvdbFilepath)
     : _interval((uint64_t)(90000 / frequency))
 {
-    
+    _klvParser.setKlvdbFilepath(klvdbFilepath);
 }
 
 void Mpeg2TsDecoder::onPacket(lcss::TransportPacket& pckt)

--- a/MiDemux/src/Mpeg2TsDecoder.h
+++ b/MiDemux/src/Mpeg2TsDecoder.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mp2tp/libmp2tp.h>
+#include <string>
 
 #include "PmtProxy.h"
 #include "AccessUnit.h"
@@ -15,7 +16,7 @@ class Mpeg2TsDecoder
     : public lcss::TSParser
 {
 public:
-    Mpeg2TsDecoder(float frequency);
+    Mpeg2TsDecoder(float frequency, const std::string& klvdbFilepath);
 
     void onPacket(lcss::TransportPacket& pckt);
 

--- a/README.md
+++ b/README.md
@@ -62,18 +62,22 @@ The `-C` option specifies the build configuration to test, either `Debug` or `Re
 ## Usage
 
 ```
-KlvDecoder v1.0.0
+KlvDecoder v1.2.0
 Copyright (c) 2025 ThetaStream Consulting, jimcavoy@thetastream.com
 Allowed options.:
-  -? [ --help ]          Produce help message.
-  --source arg           Source Motion Imagery stream or file. (default: - )
-  -r [ --reads ] arg     Number of KLV reads. Zero means continuous reads.
-                         (default: 0
-  -f [ --freqs ] arg     Frequency (Hz) to output the text representation.
-                         (default: 1)
-  -F [ --format ] arg    Output text format [info|json|xml]. (default: json).
-  -o [ --outputUrl ] arg Stream the text representation over UDP. If the option
-                         is missing, output to console. (default: - )
+  -? [ --help ]              Produce help message.
+  --source arg               The source Motion Imagery stream or file. 
+                             (default: - )
+  -r [ --reads ] arg         Number of KLV reads. Zero means continuous reads. 
+                             (default: 0)
+  -f [ --freqs ] arg         Frequency (Hz) to output the text representation. 
+                             (default: 1)
+  -F [ --format ] arg        Output text format [info|json|xml]. (default: 
+                             json).
+  -o [ --outputUrl ] arg     Stream the text representation over UDP. If the 
+                             option is empty, output to console.
+  -k [ --klvdbFilepath ] arg The filepath to klv.s3db file.
+
 ```
 The `--outputUrl` option has an optional query component with the following attribute-value pairs:
 

--- a/src/CmdLineParser.cpp
+++ b/src/CmdLineParser.cpp
@@ -16,6 +16,11 @@ public:
     std::string _format{ "json" };
     std::string _source{ "-" };
     std::string _outputUrl{ "-" };
+#ifdef _WIN32
+    std::string _klvdbFilepath{ "file:///C:/PROGRA~1/klvp/share/klv.s3db" };
+#else
+    std::string _klvdbFilepath{ "file:///usr/local/share/klv.s3db" };
+#endif
 };
 
 CmdLineParser::CmdLineParser()
@@ -45,6 +50,7 @@ int CmdLineParser::parse(int argc, char** argv)
             ("freqs,f", po::value<float>(&_pimpl->_frequency), "Frequency (Hz) to output the text representation. (default: 1)")
             ("format,F", po::value<std::string>(&_pimpl->_format), "Output text format [info|json|xml]. (default: json).")
             ("outputUrl,o", po::value<std::string>(&_pimpl->_outputUrl), "Stream the text representation over UDP. If the option is missing, output to console. (default: - )")
+            ("klvdbFilepath,k", po::value<std::string>(&_pimpl->_klvdbFilepath), "The filepath to klv.s3db file.")
             ;
 
         po::command_line_parser parser{ argc, argv };
@@ -110,4 +116,9 @@ std::string CmdLineParser::source() const
 std::string CmdLineParser::outputUrl() const
 {
     return _pimpl->_outputUrl;
+}
+
+std::string CmdLineParser::klvdbFilepath() const
+{
+    return _pimpl->_klvdbFilepath;
 }

--- a/src/CmdLineParser.cpp
+++ b/src/CmdLineParser.cpp
@@ -45,11 +45,11 @@ int CmdLineParser::parse(int argc, char** argv)
 
         desc.add_options()
             ("help,?", "Produce help message.")
-            ("source", po::value<string>(&_pimpl->_source), "Source Motion Imagery stream or file. (default: - )")
-            ("reads,r", po::value<int>(&_pimpl->_reads), "Number of KLV reads. Zero means continuous reads. (default: 0")
+            ("source", po::value<string>(&_pimpl->_source), "The source Motion Imagery stream or file. (default: - )")
+            ("reads,r", po::value<int>(&_pimpl->_reads), "Number of KLV reads. Zero means continuous reads. (default: 0)")
             ("freqs,f", po::value<float>(&_pimpl->_frequency), "Frequency (Hz) to output the text representation. (default: 1)")
             ("format,F", po::value<std::string>(&_pimpl->_format), "Output text format [info|json|xml]. (default: json).")
-            ("outputUrl,o", po::value<std::string>(&_pimpl->_outputUrl), "Stream the text representation over UDP. If the option is missing, output to console. (default: - )")
+            ("outputUrl,o", po::value<std::string>(&_pimpl->_outputUrl), "Stream the text representation over UDP. If the option is empty, output to console.")
             ("klvdbFilepath,k", po::value<std::string>(&_pimpl->_klvdbFilepath), "The filepath to klv.s3db file.")
             ;
 

--- a/src/CmdLineParser.h
+++ b/src/CmdLineParser.h
@@ -24,6 +24,7 @@ public:
     FORMAT format() const;
     std::string source() const;
     std::string outputUrl() const;
+    std::string klvdbFilepath() const;
 
 private:
     class Impl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -188,7 +188,7 @@ int main(int argc, char* argv[])
 
     try
     {
-        MiDemux demux(args.frequency());
+        MiDemux demux(args.frequency(), args.klvdbFilepath());
         UrlParser urlp;
         urlp.parse(args.outputUrl());
         KlvTextWriter writer(urlp.ipaddress.c_str(), urlp.port, urlp.ttl, urlp.ifaceaddress.c_str());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -271,7 +271,7 @@ int main(int argc, char* argv[])
 
 void Banner()
 {
-    std::cerr << "KlvDecoder v1.0.1" << std::endl;
+    std::cerr << "KlvDecoder v1.2.0" << std::endl;
     std::cerr << "Copyright (c) 2025 ThetaStream Consulting, jimcavoy@thetastream.com" << std::endl;
 }
 


### PR DESCRIPTION
Added a new command line option `klvdbFilepath`.  Users can use this option to specify the filepath to the `klv.s2db` database file.