### PR TITLE
Migrate to Visual Studio 2026

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 cmake_minimum_required (VERSION 3.21)
 project (KlvDecoder
-	VERSION 1.2.0
+	VERSION 1.2.1
 	DESCRIPTION "Converts KLV binary encoded metadata in a STANAG 4609 Motion Imagery stream to a human readable text format."
 	LANGUAGES CXX)
 
@@ -24,6 +24,12 @@ target_sources(KlvDecoder
     src/CmdLineParser.h
     src/KlvTextWriter.cpp
     src/KlvTextWriter.h
+)
+
+# specify the C++ standard
+target_compile_features(MiDemux
+  PUBLIC 
+    cxx_std_20
 )
 
 target_include_directories(KlvDecoder

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,7 +3,7 @@
     "configurePresets": [
         {
             "name": "windows-base",
-            "generator": "Visual Studio 17 2022",
+            "generator": "Visual Studio 18 2026",
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl.exe",

--- a/MiDemux/CMakeLists.txt
+++ b/MiDemux/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.21)
 
 project(MiDemux
-  VERSION 1.2.0
+  VERSION 1.2.1
   DESCRIPTION "STANAG 4609 Motion Imagery De-multiplexer"
   LANGUAGES CXX
 )
@@ -27,7 +27,6 @@ find_package(klvp 1 CONFIG REQUIRED)
 set(ldsdb_DIR ${klvp_DIR}/../ldsdb)
 find_package(ldsdb 1 CONFIG REQUIRED)
 find_package(unofficial-sqlite3 CONFIG REQUIRED)
-find_package(Microsoft.GSL CONFIG REQUIRED)
 set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost REQUIRED COMPONENTS property_tree)
 
@@ -60,7 +59,7 @@ set_property(TARGET MiDemux PROPERTY POSITION_INDEPENDENT_CODE ON)
 # specify the C++ standard
 target_compile_features(MiDemux
   PUBLIC 
-    cxx_std_17
+    cxx_std_20
 )
 
 target_include_directories(MiDemux
@@ -76,6 +75,5 @@ target_link_libraries(MiDemux
     lcss::klvp
     lcss::ldsdb
     lcss::mp2tp
-    Microsoft.GSL::GSL
     Boost::property_tree
 )

--- a/MiDemux/src/KlvDecodeVisitor.cpp
+++ b/MiDemux/src/KlvDecodeVisitor.cpp
@@ -7,7 +7,6 @@
 #include <iostream>
 #include <iomanip>
 #include <sstream>
-#include <gsl/gsl>
 #include <regex>
 
 #ifdef WIN32
@@ -618,7 +617,7 @@ void KlvDecodeVisitor::Visit(lcss::KLVSecurityLocalMetadataSet& klv)
     KlvSecuritySetVisitor pv(array, _ldsDb);
     KlvSecuritySetParserImpl ssp(pv);
     const int len = klv.length() + numOfBytesEncoded;
-    ssp.parse({ ss, gsl::narrow_cast<std::size_t>(len) });
+    ssp.parse({ ss, static_cast<std::size_t>(len) });
 
     pt::ptree::value_type vt("Security_Set", array);
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,6 @@
     "boost-program-options",
     "boost-property-tree",
     "boost-url",
-    "ms-gsl",
     "sqlite3"
   ]
 }


### PR DESCRIPTION
On Windows, migrate to Visual Studio 2026.
Remove GSL package.
Bump version to 1.2.2
Update to C++20.