### PR TITLE
Bump Version

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -271,8 +271,8 @@ int main(int argc, char* argv[])
 
 void Banner()
 {
-    std::cerr << "KlvDecoder v1.2.0" << std::endl;
-    std::cerr << "Copyright (c) 2025 ThetaStream Consulting, jimcavoy@thetastream.com" << std::endl;
+    std::cerr << "KlvDecoder v1.2.1" << std::endl;
+    std::cerr << "Copyright (c) 2026 ThetaStream Consulting, jimcavoy@thetastream.com" << std::endl;
 }
 
 #ifdef _WIN32


### PR DESCRIPTION
Bump version to 1.2.1.
Updated copyright year to 2026.
Only text string for the banner has been modified.